### PR TITLE
fix: Added wait for final key press before completely closing TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bigbrainwordle"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "rand",
  "ratatui",

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,13 +1,13 @@
 use std::io;
 
 use ratatui::{
-    Frame, Terminal,
     backend::Backend,
     crossterm::event::{self, Event, KeyCode},
     layout::{Constraint, Direction, Layout},
     style::{Color, Style},
     text::{Line, Span, Text},
     widgets::{Paragraph, Widget, Wrap},
+    Frame, Terminal,
 };
 
 use crate::{
@@ -96,8 +96,8 @@ impl App {
             }
 
             if self.state != AppState::Playing {
-                //draw again for the last time
                 term.draw(|f| self.draw(f))?;
+                let _ = event::read()?;
                 return Ok(());
             }
         }


### PR DESCRIPTION
Not sure if it was because I'm on MacOS, but when I tried using this cool tool, I encountered an issue where it would close immediately upon Wordle resolution, not giving me more than 100 ms to read the final word.

Went ahead and implemented a blocking wait for user input before totally closing the TUI